### PR TITLE
Use correct llama3_8b fp16 azure URL

### DIFF
--- a/llama_benchmarking.md
+++ b/llama_benchmarking.md
@@ -27,7 +27,7 @@ Create a SAS token in Azure:
 
 ```
 azcopy copy \
-'https://sharkblobs.blob.core.windows.net/halo-models/llm-dev/llama3_8b/8b_fp16.irpa?[Add SAS token here]' \
+'https://sharkblobs.blob.core.windows.net/halo-models/llm-dev/llama3_8b/8b_f16.irpa?[Add SAS token here]' \
 '8b_fp16.irpa'
 ```
 


### PR DESCRIPTION
When trying to download the llama3_8b fp16 irpa file, the file name could not be found as the file is called `8b_f16.irpa` instead of `8b_fp16.irpa` (I guess it likely got renamed)?